### PR TITLE
fix: make character under cursor readable in alacritty ristretto theme

### DIFF
--- a/themes/ristretto/alacritty.toml
+++ b/themes/ristretto/alacritty.toml
@@ -22,7 +22,7 @@ white   = "#f1e5e7"
 
 [colors.cursor]
 cursor = '#c3b7b8'
-text = '#c3b7b8'
+text = '#2c2525'
 
 [colors.primary]
 background = '#2c2525'


### PR DESCRIPTION
The cursor and text color in the ristretto alactritty theme config are currently the same. This change sets the cursor text color to match the background color. This should be the expected behavior.